### PR TITLE
Do not interpret backslashes when copying lines

### DIFF
--- a/debtap
+++ b/debtap
@@ -3515,7 +3515,7 @@ if [ -e preinst ] || [ -e postinst ] || [ -e prerm ] || [ -e postrm ]; then
     IFS=$'\n'
     if [ -e preinst ] && [ -e postinst ]; then
 	echo "pre_install() {" > tempfile
-	grep -iv '#!\|automatically\|added\|generated' preinst | while read line; do
+	grep -iv '#!\|automatically\|added\|generated' preinst | while read -r line; do
 	    echo "    $line" | sed s'/        /    /g' >> tempfile
 	done
 	echo "}" >> tempfile


### PR DESCRIPTION
Not much of a Bash ninja here, but I think there should be no backslash interpretation happening here since lines are just copied as-are. Fixes my case, at least...
https://github.com/helixarch/debtap/issues/11