### PR TITLE
Fix debtap package database check to support updated pkgfile cache filenames

### DIFF
--- a/debtap
+++ b/debtap
@@ -148,7 +148,7 @@ elif [[ $(file -S -b "${@: -1}" | grep -q "Debian binary package"; echo $?) != 0
 	echo -e "${red}Error: You haven't specified a valid deb package${NC}"; exit 1
 fi
 
-if [[ ! $(ls /var/cache/pkgfile | egrep '*.files?(.[[:digit:]]{3})' 2> /dev/null) ]] || [[ ! $(ls /var/cache/debtap/*-packages-files 2> /dev/null) ]] || [[ ! -e /var/cache/debtap/base-packages ]] || [[ ! -e /var/cache/debtap/aur-packages ]] || [[ ! -e /var/cache/debtap/virtual-packages ]]; then
+if [[ ! $(ls /var/cache/pkgfile 2> /dev/null | egrep '*.files?(.[[:digit:]]{3})') ]] || [[ ! $(ls /var/cache/debtap/*-packages-files 2> /dev/null) ]] || [[ ! -e /var/cache/debtap/base-packages ]] || [[ ! -e /var/cache/debtap/aur-packages ]] || [[ ! -e /var/cache/debtap/virtual-packages ]]; then
 	if [[ $pseudo != set ]]; then
 		echo -e "${red}Error: You must run at least once \"debtap -u\" with root privileges (preferably recently), before running this script${NC}"; exit 1
 	else


### PR DESCRIPTION
PR Description:
This PR addresses an issue where debtap fails with the misleading error:
"Error: You must run at least once 'debtap -u' with root privileges..."
even when debtap -u has already been run successfully.

Problem:
Github Issue - https://github.com/helixarch/debtap/issues/92

Fix:
Replaced the strict glob pattern with a more flexible expression using grep -E:
```
if [[ ! $(ls /var/cache/pkgfile 2> /dev/null | grep -E '.*\.files(\.[[:digit:]]{3})?') ]] ...
```
This allows the check to recognize both unsuffixed and suffixed .files entries.

Notes:
- Ensures compatibility with updated versions of pkgfile that store cache files with numeric suffixes.
- Only affects the initial environment check; other parts of debtap are unaffected.
- Solves the issue for systems using the new cache structure.